### PR TITLE
Ignore "No storage available" errors in 3p contexts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # web-request-mediator ChangeLog
 
+## 2.0.4 - 2023-02-dd
+
+### Fixed
+- Handle storage errors in third party contexts on any browser that
+  requires a first party dialog to access storage.
+
 ## 2.0.3 - 2023-02-21
 
 ### Fixed

--- a/PermissionManager.js
+++ b/PermissionManager.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2023 Digital Bazaar, Inc. All rights reserved.
  */
 import localforage from './storage.js';
 
@@ -50,10 +50,7 @@ export class PermissionManager {
         return status;
       }
     } catch(e) {
-      // special-case brave; it has no storage in 3rd party context
-      if(!navigator.brave || !e.message.startsWith('No available storage')) {
-        throw e;
-      }
+      _throwIfNotNoStorageError(e);
     }
 
     // return default permission descriptor (state of `prompt`)
@@ -89,11 +86,7 @@ export class PermissionManager {
           const permissions = await this.permissions;
           await permissions.setItem(permissionDesc.name, storeStatus);
         } catch(e) {
-          // special-case brave; it has no storage in 3rd party context
-          if(!navigator.brave ||
-            !e.message.startsWith('No available storage')) {
-            throw e;
-          }
+          _throwIfNotNoStorageError(e);
         }
       }
       // return clean status
@@ -119,10 +112,7 @@ export class PermissionManager {
       const permissions = await this.permissions;
       await permissions.setItem(permissionDesc.name, {state: 'prompt'});
     } catch(e) {
-      // special-case brave; it has no storage in 3rd party context
-      if(!navigator.brave || !e.message.startsWith('No available storage')) {
-        throw e;
-      }
+      _throwIfNotNoStorageError(e);
     }
     // call `query` according to spec
     return this.query(permissionDesc);
@@ -173,4 +163,12 @@ export class PermissionManager {
 
 async function deny() {
   return {state: 'denied'};
+}
+
+function _throwIfNotNoStorageError(error) {
+  // ignore lack of storage in 3rd party context in some browsers; in those
+  // browsers a first party dialog will be used to access storage
+  if(!e.message.startsWith('No available storage')) {
+    throw error;
+  }
 }


### PR DESCRIPTION
Browsers with these errors must be properly detected and load the mediator in a first party dialog to access storage.